### PR TITLE
feat: settings screen with components in place

### DIFF
--- a/src/screens/Settings.js
+++ b/src/screens/Settings.js
@@ -2,11 +2,44 @@ import React, { Component } from 'react';
 
 import { Redirect } from 'react-router-dom'
 
+import SettingsPublicTab from '../components/SettingsPublicTab'
+import SettingsAccountTab from '../components/SettingsAccountTab'
+import SettingsSyncTab from '../components/SettingsSyncTab'
+
 export default class Settings extends Component {
+
+  constructor(props) {
+    super(props)
+    this.state = {
+      currentTab: 1
+    }
+  }
+
+  viewPublicTab = () => {this.setState({ currentTab : 1 })}
+
+  viewAccountTab = () => { this.setState({ currentTab: 2 }) }
+
+  viewSyncTab = () => { this.setState({ currentTab: 3 }) }
+
+  renderCurrentTab = () => {
+    if (this.state.currentTab === 1) {
+      return <SettingsPublicTab />
+    } else if (this.state.currentTab === 2) {
+      return <SettingsAccountTab />
+    } else {
+      return <SettingsSyncTab />
+    }
+  }
+
   render() {
     if (this.props.loggedIn) {
       return (
-        <h1>Sou Settings</h1>
+        <div>
+          <button onClick={this.viewPublicTab}>Public Tab</button>
+          <button onClick={this.viewAccountTab}>Account Tab</button>
+          <button onClick={this.viewSyncTab}>Sync Tab</button>
+          {this.renderCurrentTab()}
+        </div>
       );
     } else {
       return <Redirect to='/login' />


### PR DESCRIPTION
I have just created a quick settings screen with all the components in place. This is ready for production. I will shift my focus to the components themselves now (in this case, the tabs).

Review and merge with no problem ;)

PS: Travis builds are failing due to the fact that we are using this https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie/Simple_document.cookie_framework. For some reason ESLint is picking up some errors in the RegEx. Until we switch it builds will keep failing. I will start working on it now.

Resolves #8 