### PR TITLE
fix: wrong cookie domain

### DIFF
--- a/src/screens/Login.js
+++ b/src/screens/Login.js
@@ -21,7 +21,7 @@ export default class Login extends Component {
         if (res.ok === 0) {
           alert('Login errado')
         } else {
-          Cookies.setItem('access_token', res.token, Infinity)
+          Cookies.setItem('access_token', res.token, Infinity, '/', 'api.upframe.io', true)
           this.props.setLoggedInState(true)
         }
       })


### PR DESCRIPTION
We weren't telling our cookies where their domain was 😢 
This was leading a wrong JWT token error because the token wasn't being sent.

Now this is fixed 😄 

Ready for review and merge