### PR TITLE
feat: main screen mentor list (final stuff)

### DIFF
--- a/src/components/MainMentorList.js
+++ b/src/components/MainMentorList.js
@@ -30,18 +30,17 @@ export default class MainMentorList extends Component {
   mentorToElement = (mentor) => {
     return (
       <Link to={'/people/' + mentor.keycode}>
-        <div className='mentor-cards'>
-          <img alt={mentor.name} src={mentor.profilePic} />
-          <p>{mentor.name}</p>
-          <p>{mentor.role} @  
-            <Link to={'/companies/' + mentor.company}>{mentor.company}</Link>
-          </p>
-          <p>{mentor.bio}</p>
-          <p>{mentor.tags}</p>
-          {/* <ul>
+        <div className='mentor-card'>
+          <img className='mentor-card-image' src={mentor.profilePic} alt={mentor.name}/>
+          <div className='mentor-card-info'>
+            <p><strong>{mentor.name}</strong></p>
+            <p>{mentor.role} @ <Link to={'/companies/' + mentor.company}>{mentor.company}</Link></p>
+            <p>{mentor.bio}</p>
+          </div>
+          {/*DEBUG for now <ul className='mentor-card-tags'>
             {this.mentorTagsToElement(mentor.tags)}
           </ul> */}
-          Fim
+          <p>{mentor.tags}</p>
         </div>
       </Link>
     )


### PR DESCRIPTION
Last toiches on a mentor list for the main screen. This component will need further tweaking since it doesn't supports mentor tags yet! Let's leave it as is for now and once we get that working on the settings screen we will implement it here.

Ready for review and merge!

Resolves #4 